### PR TITLE
fix(modal.js) モーダル終了後カードの周りに色枠を非表示に#118

### DIFF
--- a/src/js/modal.js
+++ b/src/js/modal.js
@@ -29,6 +29,7 @@ function setcolorbox() {
   $('.card-wrap-btn').colorbox({
     opacity: 0.7,
     iframe: true,
+    returnFocus:false,
     innerWidth: modalWidth,   //幅の指定
     innerHeight: modalHeight //高さの指定
   });


### PR DESCRIPTION
#118 

モーダル終了後のカードフォーカスをオフにしました。
<img width="297" alt="2017-12-12 14 11 37" src="https://user-images.githubusercontent.com/32658908/33868448-6ae09ace-df46-11e7-9786-d74f8379be74.png">
