### PR TITLE
fix(modal.js) モーダルの高さ判定の修正　＃125

### DIFF
--- a/src/js/modal.js
+++ b/src/js/modal.js
@@ -10,7 +10,8 @@ function setcolorbox() {
     modalHeight = 1427;
   }
   else {
-    modalWidth = width - 64;
+    width = width - 64;
+    modalWidth = width;
     if (width < 768) {
       modalHeight =1540;
     }


### PR DESCRIPTION
#125 

特定の幅のときにモーダル画面のGoogleMapが見切れていたのを修正しました
単なる条件ミスでした確認をお願いします！
修正前
<img width="704" alt="2017-12-12 15 49 15" src="https://user-images.githubusercontent.com/32658908/33871191-c47c0286-df54-11e7-8cdd-a911d8988759.png">
修正後
<img width="656" alt="2017-12-12 15 56 14" src="https://user-images.githubusercontent.com/32658908/33871246-08be131c-df55-11e7-8c4b-4cbf331370f0.png">
