### PR TITLE
一部のカードで名前がはみ出してしまっている 

### DIFF
--- a/src/sass/_card.scss
+++ b/src/sass/_card.scss
@@ -24,8 +24,9 @@
 
 
 .card__description {
-  padding: 8px 0;
-  font-size: 30px;
+  font-weight: 400;
+  padding: 8px;
+  font-size: 18px;
   line-height: 40px;
   text-align: center;
   color: $color-accent;


### PR DESCRIPTION
#117
## 作業内容
- `padding: 8px font-size: 18px; ` 変更
- `font-weight: 400px;` 追加

## preview
### width 300 **※SS時のバグあり**
![width 300px](https://user-images.githubusercontent.com/29697085/33876732-b0722968-df69-11e7-97df-d7ff0eb393f0.png)

### width 600
![width 600px](https://user-images.githubusercontent.com/29697085/33876737-b2a76c3e-df69-11e7-8dce-640b02eabe39.png)

### width 768
![width 768px](https://user-images.githubusercontent.com/29697085/33876741-b45fd08e-df69-11e7-84ae-98fb89c8ea24.png)

### width 960
![width 960px](https://user-images.githubusercontent.com/29697085/33876742-b6041bd4-df69-11e7-9a40-0d03d24a85c9.png)

