### PR TITLE
fix(_card.scss):一部画面幅でカードの画像の縦横比が崩れる問題の修正 #108

### DIFF
--- a/src/sass/_card.scss
+++ b/src/sass/_card.scss
@@ -7,30 +7,27 @@
   width: 100%;
   margin-bottom: 16px;
   box-shadow: $shadow-md;
+  overflow: hidden;
+  border-radius: 3px;
 }
 
 .card__img-outer {
-  min-height: 200px;
   background-color: $color-accent;
-  border-top-left-radius: 3px;
-  border-top-right-radius: 3px;
 }
 
 .card__img {
-  padding: 0 16px;
-  box-sizing: border-box;
-  min-height: 200px;
+  display: block;
+  height: 200px;
+  margin: 0 auto;
 }
 
 
 .card__description {
   font-weight: 400;
-  padding: 8px;
+  padding: 8px 0;
   font-size: 18px;
   line-height: 40px;
   text-align: center;
   color: $color-accent;
   background-color: $color-main;
-  border-bottom-left-radius: 3px;
-  border-bottom-right-radius: 3px;
 }


### PR DESCRIPTION
#108 
画像のサイズを固定化して対処しました。
どなたか手の空いた時にレビューお願いします。
![screencapture-localhost-3000-1513134054406](https://user-images.githubusercontent.com/32005523/33919811-08ece012-dffe-11e7-8a16-dad37f96415e.png)
![screencapture-localhost-3000-1513134021655](https://user-images.githubusercontent.com/32005523/33919815-0bef8f94-dffe-11e7-924c-f499d8da2340.png)
