### PR TITLE
feat(src/sass/_modal.scss): 画像の縦横比が維持できていない #123

### DIFF
--- a/src/sass/_modal.scss
+++ b/src/sass/_modal.scss
@@ -119,6 +119,7 @@
     &__img{
       width: 200px;
       height: 200px;
+      object-fit: scale-down;
     }
     &__link{
       display: block;


### PR DESCRIPTION
#123
画像の見切れは :scale-downの値で解決できました

![2017-12-13 13 59 00](https://user-images.githubusercontent.com/31300827/33922417-1463f998-e00e-11e7-9149-ad23c83acad1.png)
